### PR TITLE
ホットリロード用設定追加

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,4 +1,12 @@
 import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
-export default defineConfig({});
+export default defineConfig({
+    vite: {
+        server: {
+            watch: {
+                usePolling: true,
+            },
+        },
+    },
+});


### PR DESCRIPTION
docker内でastroのdevを立ち上げるとホットリロードが利かないので設定追加

参考
https://lilly-dog.dev/note/post15